### PR TITLE
Separates lists of Subnote objects from strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Setuptools distribution folder.
 /dist/
+/build/
 
 # Python egg metadata, regenerated from source files by setuptools.
 /*.egg-info

--- a/fixtures/valid/agent/5e1628f009005651fa30f337.json
+++ b/fixtures/valid/agent/5e1628f009005651fa30f337.json
@@ -31,7 +31,7 @@
             "eiusmod enim nisi dolor veniam deserunt",
             "et sunt anim velit veniam sint"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -40,7 +40,7 @@
             "ea non tempor consectetur cillum ex",
             "amet do veniam ad nisi do"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "ea voluptate ullamco"

--- a/fixtures/valid/agent/5e1628f02059510bac920201.json
+++ b/fixtures/valid/agent/5e1628f02059510bac920201.json
@@ -20,14 +20,14 @@
           "content": [
             "elit cillum laboris nisi est culpa"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
             "qui do anim eu cupidatat consectetur",
             "ad sunt magna Lorem velit exercitation"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "est est eiusmod"
@@ -44,7 +44,7 @@
             "et irure sunt sunt laborum dolor",
             "et ipsum nisi sunt sint aute"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "ad labore mollit"

--- a/fixtures/valid/agent/5e162b2c0a09165b63f9cbcd.json
+++ b/fixtures/valid/agent/5e162b2c0a09165b63f9cbcd.json
@@ -32,7 +32,7 @@
             "tempor aute deserunt nisi labore ipsum",
             "ex voluptate sint veniam Lorem occaecat"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -58,7 +58,7 @@
             "id consequat id non laboris culpa",
             "dolore sint officia fugiat et commodo"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "consequat id commodo"

--- a/fixtures/valid/agent/5e162cb71ab94260e8f149fa.json
+++ b/fixtures/valid/agent/5e162cb71ab94260e8f149fa.json
@@ -31,7 +31,7 @@
             "ad id non quis consectetur consectetur",
             "incididunt fugiat veniam officia Lorem minim"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -41,7 +41,7 @@
             "deserunt ea enim reprehenderit veniam veniam",
             "ad est ullamco tempor non mollit"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "pariatur ullamco id"
@@ -66,14 +66,14 @@
             "ea ullamco cillum veniam ullamco exercitation",
             "deserunt sint cupidatat aute veniam elit"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
-          "content": [
-            "esse qui aliqua eiusmod quis anim",
-            "laborum qui do non eu est",
-            "qui ad cupidatat ullamco aliqua eiusmod",
-            "anim sunt esse do ad cupidatat"
+          "items": [
+            {"label": "esse qui", "value": "aliqua eiusmod quis anim"},
+            {"label": "laborum qui", "value": "do non eu est"},
+            {"label": "qui ad", "value": "cupidatat ullamco aliqua eiusmod"},
+            {"label": "anim sunt", "value": "esse do ad cupidatat"}
           ],
           "type": "definedlist"
         }

--- a/fixtures/valid/agent/5e162cb71ad1aa1b2f1f02ee.json
+++ b/fixtures/valid/agent/5e162cb71ad1aa1b2f1f02ee.json
@@ -23,7 +23,7 @@
             "nostrud anim minim cillum excepteur deserunt",
             "aliquip in tempor duis velit nostrud"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -41,7 +41,7 @@
             "irure proident nulla enim laboris et",
             "veniam Lorem sit eu fugiat fugiat"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "fugiat ea tempor"

--- a/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
+++ b/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
@@ -40,8 +40,8 @@
       "type": "extent",
       "subnotes": [
         {
-          "content": [
-            "nulla proident fugiat mollit voluptate nostrud"
+          "items": [
+            {"label": "nulla proident", "value": "nulla proident fugiat mollit voluptate nostrud"}
           ],
           "type": "orderedlist"
         },
@@ -72,21 +72,18 @@
       "type": "physfacet",
       "subnotes": [
         {
-          "content": [
-            "ea reprehenderit ad laboris proident magna",
-            "deserunt consequat quis ex ut aliquip",
-            "aliqua reprehenderit dolore dolore esse adipisicing",
-            "est voluptate qui proident amet ut",
-            "fugiat minim velit dolore dolor duis"
+          "items": [
+            {"label": "ea reprehenderit", "value": "ad laboris proident magna"},
+            {"label": "deserunt consequat", "value": "quis ex ut aliquip"},
+            {"label": "aliqua", "value": "reprehenderit dolore dolore esse adipisicing"},
+            {"label": "est voluptate qui", "value": "proident amet ut"},
+            {"label": "fugiat", "value": "minim velit dolore dolor duis"}
           ],
           "type": "definedlist"
         },
         {
-          "content": [
-            "nostrud mollit consequat amet do commodo",
-            "tempor adipisicing pariatur excepteur dolore officia",
-            "ut velit duis commodo ipsum duis",
-            "aliquip tempor eu mollit voluptate ipsum"
+          "items": [
+            {"label": "nostrud", "value": "mollit consequat amet do commodo"}
           ],
           "type": "orderedlist"
         }
@@ -105,7 +102,7 @@
             "dolore ullamco mollit velit magna velit",
             "cupidatat duis voluptate ea culpa dolor"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "occaecat velit duis"
@@ -120,7 +117,7 @@
             "proident commodo laboris sint esse duis",
             "sint adipisicing do anim dolor consequat"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [

--- a/fixtures/valid/collection/5e16514c5e5a38c49f32db05.json
+++ b/fixtures/valid/collection/5e16514c5e5a38c49f32db05.json
@@ -48,10 +48,10 @@
       "type": "userestrict",
       "subnotes": [
         {
-          "content": [
-            "esse esse non Lorem incididunt elit",
-            "id minim adipisicing aute elit eiusmod",
-            "exercitation ut non cupidatat do eu"
+          "items": [
+            {"label": "esse esse", "value": "non Lorem incididunt elit"},
+            {"label": "id minim", "value": "adipisicing aute elit eiusmod"},
+            {"label": "exercitation", "value": "ut non cupidatat do eu"}
           ],
           "type": "orderedlist"
         },
@@ -59,7 +59,7 @@
           "content": [
             "labore consequat consequat ex deserunt Lorem"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -69,7 +69,7 @@
             "commodo incididunt velit consectetur ea commodo",
             "ad enim dolore tempor esse id"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "nostrud enim nisi"
@@ -82,7 +82,7 @@
           "content": [
             "deserunt esse adipisicing est mollit enim"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -96,7 +96,7 @@
             "adipisicing ipsum ad cillum ea incididunt",
             "sit veniam veniam commodo mollit Lorem"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "duis consectetur sint"
@@ -133,13 +133,13 @@
             "commodo tempor excepteur cupidatat in adipisicing",
             "pariatur commodo eiusmod pariatur dolore quis"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
             "culpa veniam mollit anim eu occaecat"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "aliquip incididunt voluptate"
@@ -196,8 +196,8 @@
               "subnotes": [
                 {
                   "content": [
-                    "officia proident sint eu enim exercitation",
-                    "voluptate labore labore officia do sunt"
+                    {"label": "officia", "value": "proident sint eu enim exercitation"},
+                    {"label": "voluptate labore", "value": "labore officia do sunt"}
                   ],
                   "type": "orderedlist"
                 },

--- a/fixtures/valid/collection/5e16514c7a5575305c335aa5.json
+++ b/fixtures/valid/collection/5e16514c7a5575305c335aa5.json
@@ -115,7 +115,7 @@
             "sunt labore incididunt quis fugiat consectetur",
             "id irure reprehenderit mollit ullamco anim"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [

--- a/fixtures/valid/object/5e164dbc01da72ffd828c3ca.json
+++ b/fixtures/valid/object/5e164dbc01da72ffd828c3ca.json
@@ -48,7 +48,7 @@
             "pariatur excepteur magna nulla anim sit",
             "ea adipisicing ullamco consequat nulla nulla"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -56,13 +56,13 @@
             "aliquip duis dolor proident esse officia",
             "exercitation nisi sunt officia eiusmod sunt"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
             "occaecat tempor reprehenderit ut eu ut"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "fugiat id irure"
@@ -84,7 +84,7 @@
             "velit dolor sunt incididunt commodo ullamco",
             "amet eu amet ullamco mollit irure"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -105,7 +105,7 @@
           "content": [
             "dolore minim est et enim aliquip"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "reprehenderit Lorem cupidatat"
@@ -139,7 +139,7 @@
                 "mollit quis laborum labore ad tempor",
                 "anim duis incididunt nostrud nostrud ipsum"
               ],
-              "type": "orderedlist"
+              "type": "text"
             }
           ],
           "title": "ut labore eiusmod"
@@ -158,12 +158,12 @@
               "type": "type_note",
               "subnotes": [
                 {
-                  "content": [
-                    "esse mollit labore esse cupidatat anim",
-                    "aliqua velit ad amet voluptate eiusmod",
-                    "ut dolor velit ex aliquip ad",
-                    "ex anim est eu non irure",
-                    "cillum eiusmod minim nulla est duis"
+                  "items": [
+                    {"label": "esse mollit", "value": "labore esse cupidatat anim"},
+                    {"label": "aliqua", "value": "velit ad amet voluptate eiusmod"},
+                    {"label": "ut dolor velit", "value": "ex aliquip ad"},
+                    {"label": "ex anim", "value": "est eu non irure"},
+                    {"label": "cillum", "value": "eiusmod minim nulla est duis"}
                   ],
                   "type": "orderedlist"
                 },
@@ -172,7 +172,7 @@
                     "dolore quis in excepteur anim eu",
                     "veniam reprehenderit officia fugiat sunt in"
                   ],
-                  "type": "definedlist"
+                  "type": "text"
                 }
               ],
               "title": "ad tempor officia"

--- a/fixtures/valid/object/5e164dbc0f36cd59491a231f.json
+++ b/fixtures/valid/object/5e164dbc0f36cd59491a231f.json
@@ -58,11 +58,11 @@
           "type": "permissions",
           "subnotes": [
             {
-              "content": [
-                "esse ipsum veniam anim quis ipsum",
-                "consectetur proident minim fugiat laborum cillum",
-                "minim sint id eiusmod officia duis",
-                "Lorem ut proident quis elit eu"
+              "items": [
+                {"label": "esse ipsum", "value": "veniam anim quis ipsum"},
+                {"label": "consectetur", "value": "proident minim fugiat laborum cillum"},
+                {"label": "minim sint", "value": "id eiusmod officia duis"},
+                {"label": "Lorem ut", "value": "proident quis elit eu"}
               ],
               "type": "definedlist"
             }
@@ -96,7 +96,7 @@
                     "nisi enim elit officia culpa fugiat",
                     "laborum enim labore dolor nulla voluptate"
                   ],
-                  "type": "orderedlist"
+                  "type": "text"
                 },
                 {
                   "content": [
@@ -124,7 +124,7 @@
                     "occaecat ex consectetur sint velit Lorem",
                     "velit ut occaecat exercitation reprehenderit do"
                   ],
-                  "type": "orderedlist"
+                  "type": "text"
                 }
               ],
               "title": "Lorem sit consequat"

--- a/fixtures/valid/object/5e164dbc1aee795fbc75953c.json
+++ b/fixtures/valid/object/5e164dbc1aee795fbc75953c.json
@@ -54,13 +54,13 @@
             "in sint deserunt quis exercitation fugiat",
             "velit cillum aliqua eiusmod laboris fugiat"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
-          "content": [
-            "sunt minim ex tempor elit id",
-            "dolor reprehenderit est ea cupidatat laboris",
-            "ut ullamco irure exercitation nostrud culpa"
+          "items": [
+            {"label": "sunt minim", "value": "ex tempor elit id"},
+            {"label": "dolor", "value": "reprehenderit est ea cupidatat laboris"},
+            {"label": "ut ullamco", "value": "irure exercitation nostrud culpa"}
           ],
           "type": "orderedlist"
         }
@@ -77,7 +77,7 @@
             "do Lorem laborum consectetur nostrud tempor",
             "deserunt exercitation consequat excepteur ea culpa"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -85,7 +85,7 @@
             "sunt eiusmod reprehenderit amet anim sint",
             "exercitation irure proident anim esse id"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -95,7 +95,7 @@
             "laboris exercitation eiusmod reprehenderit magna enim",
             "officia sit cupidatat anim excepteur ad"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "tempor irure excepteur"
@@ -109,7 +109,7 @@
             "reprehenderit elit ex sunt sint consequat",
             "deserunt dolore irure ea consequat laborum"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "aliqua do ea"
@@ -124,7 +124,7 @@
             "ipsum mollit dolore reprehenderit consequat duis",
             "exercitation magna id duis eu minim"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -134,15 +134,15 @@
             "consequat reprehenderit laboris deserunt ad eiusmod",
             "magna adipisicing fugiat nisi et irure"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
-          "content": [
-            "ad nisi do exercitation exercitation deserunt",
-            "commodo duis officia voluptate nostrud excepteur",
-            "ad dolor laborum sint nostrud amet"
+          "items": [
+            {"label": "ad nisi", "value": "do exercitation exercitation deserunt"},
+            {"label": "commodo", "value": "duis officia voluptate nostrud excepteur"},
+            {"label": "ad dolor", "value": "laborum sint nostrud amet"}
           ],
-          "type": "text"
+          "type": "orderedlist"
         }
       ],
       "title": "minim irure mollit"
@@ -245,7 +245,7 @@
                   "content": [
                     "do sint aute sint sit mollit"
                   ],
-                  "type": "orderedlist"
+                  "type": "text"
                 },
                 {
                   "content": [
@@ -253,7 +253,7 @@
                     "dolore consequat incididunt in non adipisicing",
                     "aute laborum ullamco cillum voluptate minim"
                   ],
-                  "type": "definedlist"
+                  "type": "text"
                 }
               ],
               "title": "reprehenderit amet ad"

--- a/fixtures/valid/object/5e164dbc2ea4bea04e0d8e86.json
+++ b/fixtures/valid/object/5e164dbc2ea4bea04e0d8e86.json
@@ -56,7 +56,7 @@
             "excepteur incididunt proident excepteur velit et",
             "enim pariatur eu nisi fugiat in"
           ],
-          "type": "orderedlist"
+          "type": "text"
         }
       ],
       "title": "consectetur id et"
@@ -73,7 +73,7 @@
             "quis tempor aliqua magna ut sunt",
             "ullamco cillum officia id reprehenderit ullamco"
           ],
-          "type": "orderedlist"
+          "type": "text"
         },
         {
           "content": [
@@ -82,7 +82,7 @@
             "consectetur duis magna nulla magna nisi",
             "amet ullamco proident ut tempor dolor"
           ],
-          "type": "definedlist"
+          "type": "text"
         }
       ],
       "title": "dolor adipisicing duis"
@@ -101,7 +101,7 @@
           "content": [
             "enim incididunt non nisi ad commodo"
           ],
-          "type": "definedlist"
+          "type": "text"
         },
         {
           "content": [

--- a/fixtures/valid/object/5e164dbc3ae235e3bff9ac0a.json
+++ b/fixtures/valid/object/5e164dbc3ae235e3bff9ac0a.json
@@ -123,7 +123,7 @@
                     "irure ut exercitation ad laborum cupidatat",
                     "dolor laborum nostrud voluptate duis aute"
                   ],
-                  "type": "definedlist"
+                  "type": "text"
                 },
                 {
                   "content": [
@@ -133,7 +133,7 @@
                     "dolor sit ad est consequat nostrud",
                     "esse quis labore Lorem eiusmod anim"
                   ],
-                  "type": "orderedlist"
+                  "type": "text"
                 }
               ],
               "title": "consequat exercitation labore"

--- a/schemas/base.json
+++ b/schemas/base.json
@@ -327,7 +327,9 @@
 					"type": "array",
 					"minItems": 1,
 					"items": {
-						"allOf": [{"$ref": "#/definitions/subnote"}]
+						"allOf": [{
+							"$ref": "#/definitions/subnote"
+						}]
 					}
 				}
 			}
@@ -344,7 +346,9 @@
 					"type": "array",
 					"minItems": 1,
 					"items": {
-						"allOf": [{"$ref": "#/definitions/external_identifier"}]
+						"allOf": [{
+							"$ref": "#/definitions/external_identifier"
+						}]
 					}
 				},
 				"level": {
@@ -402,7 +406,7 @@
 				},
 				"type": {
 					"$id": "#/definitions/reference/properties/type",
-					"type": ["string","null"],
+					"type": ["string", "null"],
 					"title": "Type",
 					"description": "Reference type",
 					"enum": [
@@ -426,7 +430,7 @@
 				},
 				"uri": {
 					"$id": "#/definitions/reference/properties/uri",
-					"type": ["string","null"],
+					"type": ["string", "null"],
 					"title": "URI",
 					"description": "Relative link",
 					"examples": [
@@ -668,10 +672,7 @@
 			"$id": "#/definitions/subnote",
 			"type": "object",
 			"title": "Subnotes",
-			"required": [
-				"content",
-				"type"
-			],
+			"required": ["type"],
 			"properties": {
 				"type": {
 					"$id": "#/definitions/subnote/properties/type",
@@ -697,15 +698,27 @@
 					"title": "Subnote Content",
 					"items": {
 						"$id": "#/definitions/subnote/properties/content/items",
-						"type": "string",
+						"type": ["string", "null"],
 						"title": "Content Items",
-						"minLength": 1,
 						"examples": [
 							"cupidatat quis culpa amet labore incididunt",
 							"ullamco in Lorem ad minim labore",
 							"laborum dolore adipisicing aliquip incididunt ad",
 							"elit ipsum quis ex do dolore"
 						]
+					}
+				},
+				"items": {
+					"$id": "#/definitions/subnote/properties/items",
+					"type": "array",
+					"title": "Subnote Items",
+					"items": {
+						"$id": "#/definitions/subnote/properties/items/items",
+						"type": ["object", "null"],
+						"title": "Items Items",
+						"examples": [{
+							"label": "value"
+						}]
 					}
 				}
 			}

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,25 @@
 from setuptools import setup
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(name='rac_schemas',
-      version='0.1',
+      version='0.2',
       description='RAC JSON Schemas and validators',
       url='http://github.com/RockefellerArchiveCenter/rac_schemas',
       author='Rockefeller Archive Center',
       author_email='archive@rockarch.org',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
       install_requires=['jsonschema'],
       license='MIT',
       packages=['rac_schemas'],
       test_suite='nose.collector',
       tests_require=['nose', 'jsonschema'],
-      zip_safe=False)
+      zip_safe=False,
+      classifiers=[
+          "Programming Language :: Python :: 3",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: OS Independent",
+      ],
+      python_requires='>=3.6',)

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -51,6 +51,7 @@ class TestSchemas(unittest.TestCase):
         for object_type in listdir(join(fixtures_dir, "valid")):
             for f in listdir(join(fixtures_dir, "valid", object_type)):
                 with open(join(fixtures_dir, "valid", object_type, f), "r") as df:
+                    print(object_type, f)
                     data = json.load(df)
                     is_valid(data, object_type)
         for object_type in listdir(join(fixtures_dir, "invalid")):


### PR DESCRIPTION
Adds an `item` key in Subnote, into which all subnote content structured as an object should go.

Bumps version to 0.2

fixes #3 