### PR TITLE
Raise local exception for validation

### DIFF
--- a/rac_schemas/exceptions.py
+++ b/rac_schemas/exceptions.py
@@ -1,0 +1,2 @@
+class ValidationError(Exception):
+    pass

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,9 +3,9 @@ import unittest
 from os import listdir
 from os.path import abspath, dirname, join
 
-from jsonschema.exceptions import ValidationError
 from jsonschema.validators import validator_for
 from rac_schemas import handle_schema_filename, is_valid
+from rac_schemas.exceptions import ValidationError
 
 base_path = dirname(dirname(abspath(__file__)))
 


### PR DESCRIPTION
This allows us not to have to import jsonschema.exceptions.ValidationError in order to catch validation issues.