### PR TITLE
Adds additional fields and format checking

### DIFF
--- a/fixtures/invalid/agent/5e162b2c0a09165b63f9cbcd0.json
+++ b/fixtures/invalid/agent/5e162b2c0a09165b63f9cbcd0.json
@@ -1,0 +1,75 @@
+{
+  "dates": [
+    {
+      "begin": "1957-12-118",
+      "end": "2002-10-21",
+      "type": "inclusive",
+      "label": "record_keeping",
+      "source": "wikidata",
+      "expression": "December 17, 1957 - October 20, 2002"
+    },
+    {
+      "begin": "1952-08-23",
+      "end": "2014-05-19",
+      "type": "bulk",
+      "label": "deaccession",
+      "source": "wikidata",
+      "expression": "August 22, 1952 - May 18, 2014"
+    }
+  ],
+  "description": "Ullamco ut amet exercitation pariatur. Labore voluptate incididunt ipsum sit magna non exercitation do ullamco esse est deserunt officia non. Incididunt sint sint velit irure qui aute amet tempor occaecat aliqua qui aliqua. Ipsum ex nostrud aliqua excepteur commodo veniam veniam excepteur proident.\r\n",
+  "title": "Allison Orr",
+  "notes": [
+    {
+      "source": "wikipedia",
+      "type": "restrictions",
+      "subnotes": [
+        {
+          "content": [
+            "magna cupidatat nisi deserunt ullamco mollit",
+            "anim amet non quis esse officia",
+            "eiusmod ipsum ea commodo aliqua non",
+            "tempor aute deserunt nisi labore ipsum",
+            "ex voluptate sint veniam Lorem occaecat"
+          ],
+          "type": "text"
+        },
+        {
+          "content": [
+            "labore nulla adipisicing veniam proident nulla",
+            "tempor irure et tempor in deserunt",
+            "do veniam qui laboris excepteur enim",
+            "dolore cillum eiusmod dolor dolor in",
+            "enim esse sit minim consectetur aute"
+          ],
+          "type": "text"
+        }
+      ],
+      "title": "ea laborum aliqua"
+    },
+    {
+      "source": "wikidata",
+      "type": "permissions",
+      "subnotes": [
+        {
+          "content": [
+            "voluptate dolor ut enim deserunt exercitation",
+            "sunt incididunt occaecat sit labore occaecat",
+            "id consequat id non laboris culpa",
+            "dolore sint officia fugiat et commodo"
+          ],
+          "type": "text"
+        }
+      ],
+      "title": "consequat id commodo"
+    }
+  ],
+  "external_identifiers": [
+    {
+      "source": "archivesspace",
+      "identifier": "/agents_person/36"
+    }
+  ],
+  "agent_type": "person",
+  "type": "agent"
+}

--- a/fixtures/invalid/collection/5e16514c00b13f54a1a0592b0.json
+++ b/fixtures/invalid/collection/5e16514c00b13f54a1a0592b0.json
@@ -1,0 +1,237 @@
+{
+  "dates": [
+    {
+      "begin": "1926-06-04",
+      "end": "2012-09-117",
+      "type": "single",
+      "label": "modified",
+      "source": "archivesspace",
+      "expression": "June 3, 1926 - September 16, 2012"
+    },
+    {
+      "begin": "1955-04-23",
+      "end": "1999-07-16",
+      "type": "inclusive",
+      "label": "existence",
+      "source": "archivesspace",
+      "expression": "April 22, 1955 - July 15, 1999"
+    }
+  ],
+  "ancestors": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/repositories/2/resources/49"
+        }
+      ]
+    }
+  ],
+  "extents": [
+    {
+      "type": "record cartons",
+      "value": "1.09"
+    }
+  ],
+  "level": "otherLevel",
+  "notes": [
+    {
+      "source": "archivesspace",
+      "type": "extent",
+      "subnotes": [
+        {
+          "items": [
+            {"label": "nulla proident", "value": "nulla proident fugiat mollit voluptate nostrud"}
+          ],
+          "type": "orderedlist"
+        },
+        {
+          "content": [
+            "consectetur reprehenderit elit mollit ea ad",
+            "culpa adipisicing culpa et eu id",
+            "esse ex deserunt amet enim fugiat",
+            "elit eiusmod nulla aute mollit ipsum"
+          ],
+          "type": "text"
+        },
+        {
+          "content": [
+            "excepteur pariatur mollit laboris dolore pariatur",
+            "est aliqua aliquip quis aliquip in",
+            "consectetur pariatur esse est nulla commodo",
+            "amet pariatur occaecat nulla adipisicing aute",
+            "eiusmod consequat nulla enim duis nulla"
+          ],
+          "type": "text"
+        }
+      ],
+      "title": "laboris veniam exercitation"
+    },
+    {
+      "source": "cartographer",
+      "type": "physfacet",
+      "subnotes": [
+        {
+          "items": [
+            {"label": "ea reprehenderit", "value": "ad laboris proident magna"},
+            {"label": "deserunt consequat", "value": "quis ex ut aliquip"},
+            {"label": "aliqua", "value": "reprehenderit dolore dolore esse adipisicing"},
+            {"label": "est voluptate qui", "value": "proident amet ut"},
+            {"label": "fugiat", "value": "minim velit dolore dolor duis"}
+          ],
+          "type": "definedlist"
+        },
+        {
+          "items": [
+            {"label": "nostrud", "value": "mollit consequat amet do commodo"}
+          ],
+          "type": "orderedlist"
+        }
+      ],
+      "title": "do consectetur commodo"
+    },
+    {
+      "source": "wikidata",
+      "type": "physloc",
+      "subnotes": [
+        {
+          "content": [
+            "et laboris labore ex nulla sint",
+            "dolor cillum laborum officia velit dolor",
+            "aute cupidatat labore est ex irure",
+            "dolore ullamco mollit velit magna velit",
+            "cupidatat duis voluptate ea culpa dolor"
+          ],
+          "type": "text"
+        }
+      ],
+      "title": "occaecat velit duis"
+    },
+    {
+      "source": "cartographer",
+      "type": "expiration",
+      "subnotes": [
+        {
+          "content": [
+            "nostrud officia nisi occaecat id sit",
+            "proident commodo laboris sint esse duis",
+            "sint adipisicing do anim dolor consequat"
+          ],
+          "type": "text"
+        },
+        {
+          "content": [
+            "ex labore qui ipsum in id"
+          ],
+          "type": "text"
+        },
+        {
+          "content": [
+            "consectetur commodo consequat incididunt occaecat non"
+          ],
+          "type": "text"
+        }
+      ],
+      "title": "consequat voluptate laboris"
+    }
+  ],
+  "title": "Deserunt excepteur id quis minim Lorem veniam exercitation commodo.",
+  "external_identifiers": [
+    {
+      "source": "archivesspace",
+      "identifier": "/repositories/2/resources/22"
+    }
+  ],
+  "children": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/repositories/2/archival_objects/20"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/repositories/2/archival_objects/48"
+        }
+      ]
+    }
+  ],
+  "languages": [
+    {
+      "identifier": "spa",
+      "expression": "Esperanto"
+    },
+    {
+      "identifier": "spa",
+      "expression": "Esperanto"
+    }
+  ],
+  "rights": [],
+  "agents": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/38"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_person/19"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_family/24"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/9"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/22"
+        }
+      ]
+    }
+  ],
+  "terms": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/terms/22"
+        }
+      ]
+    }
+  ],
+  "creators": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_family/31"
+        }
+      ]
+    }
+  ],
+  "type": "collection"
+}

--- a/fixtures/invalid/object/5e164dbc0f36cd59491a231f0.json
+++ b/fixtures/invalid/object/5e164dbc0f36cd59491a231f0.json
@@ -1,0 +1,193 @@
+{
+  "dates": [
+    {
+      "begin": "1914-09-25",
+      "end": "200-07-14",
+      "type": "bulk",
+      "label": "issued",
+      "source": "archivesspace",
+      "expression": "September 24, 1914 - July 13, 2006"
+    },
+    {
+      "begin": "1935-08-25",
+      "end": "1984-08-11",
+      "type": "bulk",
+      "label": "issued",
+      "source": "archivesspace",
+      "expression": "August 24, 1935 - August 10, 1984"
+    }
+  ],
+  "ancestors": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/repositories/2/resources/40"
+        }
+      ]
+    }
+  ],
+  "extents": [
+    {
+      "type": "document box(es)",
+      "value": "0.79"
+    }
+  ],
+  "title": "Proident in consectetur id sint minim exercitation sunt nostrud excepteur et nulla sint aliqua amet.",
+  "notes": [],
+  "external_identifiers": [
+    {
+      "source": "archivesspace",
+      "identifier": "/repositories/2/archival_objects/24"
+    }
+  ],
+  "languages": [
+    {
+      "identifier": "epo",
+      "expression": "English"
+    }
+  ],
+  "rights": [
+    {
+      "begin": "1933-04-15",
+      "end": "2001-10-13",
+      "copyright_status": "unknown",
+      "notes": [
+        {
+          "source": "wikipedia",
+          "type": "permissions",
+          "subnotes": [
+            {
+              "items": [
+                {"label": "esse ipsum", "value": "veniam anim quis ipsum"},
+                {"label": "consectetur", "value": "proident minim fugiat laborum cillum"},
+                {"label": "minim sint", "value": "id eiusmod officia duis"},
+                {"label": "Lorem ut", "value": "proident quis elit eu"}
+              ],
+              "type": "definedlist"
+            }
+          ],
+          "title": "enim veniam aliqua"
+        }
+      ],
+      "jurisdiction": "FR",
+      "other_basis": "pariatur",
+      "rights_granted": [
+        {
+          "restriction": "disallow",
+          "begin": "1914-08-28",
+          "end": "1990-03-13",
+          "notes": [
+            {
+              "source": "wikidata",
+              "type": "rights_statement_act",
+              "subnotes": [
+                {
+                  "content": [
+                    "quis consequat pariatur eiusmod anim nisi",
+                    "aliquip quis labore nostrud culpa magna"
+                  ],
+                  "type": "text"
+                },
+                {
+                  "content": [
+                    "anim reprehenderit ipsum in in ex",
+                    "consequat reprehenderit adipisicing mollit nulla duis",
+                    "nisi enim elit officia culpa fugiat",
+                    "laborum enim labore dolor nulla voluptate"
+                  ],
+                  "type": "text"
+                },
+                {
+                  "content": [
+                    "eiusmod dolore dolore aliqua occaecat do"
+                  ],
+                  "type": "text"
+                }
+              ],
+              "title": "commodo do adipisicing"
+            }
+          ],
+          "act": "use"
+        },
+        {
+          "restriction": "allow",
+          "begin": "1938-09-27",
+          "end": "1971-04-12",
+          "notes": [
+            {
+              "source": "cartographer",
+              "type": "materials",
+              "subnotes": [
+                {
+                  "content": [
+                    "occaecat ex consectetur sint velit Lorem",
+                    "velit ut occaecat exercitation reprehenderit do"
+                  ],
+                  "type": "text"
+                }
+              ],
+              "title": "Lorem sit consequat"
+            }
+          ],
+          "act": "use"
+        }
+      ],
+      "rights_status": "unknown",
+      "determination_date": "1918-07-15",
+      "type": "rights_statement",
+      "id": "5e164dbcdf91f34e470a3565",
+      "rights_type": "license"
+    },
+    {
+      "begin": "1957-09-19",
+      "end": "1985-03-30",
+      "copyright_status": "public domain",
+      "notes": [],
+      "jurisdiction": "CN",
+      "other_basis": "commodo",
+      "rights_granted": [
+        {
+          "restriction": "disallow",
+          "begin": "1927-01-03",
+          "end": "2012-09-08",
+          "notes": [],
+          "act": "disseminate"
+        }
+      ],
+      "rights_status": "copyrighted",
+      "determination_date": "1916-05-16",
+      "type": "rights_statement",
+      "id": "5e164dbc57e1f7f17fb0a093",
+      "rights_type": "other"
+    }
+  ],
+  "agents": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/45"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_person/36"
+        }
+      ]
+    },
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/20"
+        }
+      ]
+    }
+  ],
+  "terms": [],
+  "type": "object"
+}

--- a/fixtures/valid/agent/5e1628f009005651fa30f337.json
+++ b/fixtures/valid/agent/5e1628f009005651fa30f337.json
@@ -67,6 +67,16 @@
       "title": "dolore fugiat minim"
     }
   ],
+  "families": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_family/28"
+        }
+      ]
+    }
+  ],
   "external_identifiers": [
     {
       "source": "archivesspace",

--- a/fixtures/valid/agent/5e1628f02059510bac920201.json
+++ b/fixtures/valid/agent/5e1628f02059510bac920201.json
@@ -50,6 +50,16 @@
       "title": "ad labore mollit"
     }
   ],
+  "families": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_family/7"
+        }
+      ]
+    }
+  ],
   "external_identifiers": [
     {
       "source": "archivesspace",

--- a/fixtures/valid/agent/5e162b2c0a09165b63f9cbcd.json
+++ b/fixtures/valid/agent/5e162b2c0a09165b63f9cbcd.json
@@ -64,6 +64,26 @@
       "title": "consequat id commodo"
     }
   ],
+  "organizations": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/38"
+        }
+      ]
+    }
+  ],
+  "people": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_person/36"
+        }
+      ]
+    }
+  ],
   "external_identifiers": [
     {
       "source": "archivesspace",

--- a/fixtures/valid/agent/5e162cb71ab94260e8f149fa.json
+++ b/fixtures/valid/agent/5e162cb71ab94260e8f149fa.json
@@ -81,6 +81,16 @@
       "title": "consequat ipsum et"
     }
   ],
+  "organizations": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_organization/15"
+        }
+      ]
+    }
+  ],
   "external_identifiers": [
     {
       "source": "archivesspace",

--- a/fixtures/valid/agent/5e162cb71ad1aa1b2f1f02ee.json
+++ b/fixtures/valid/agent/5e162cb71ad1aa1b2f1f02ee.json
@@ -47,6 +47,16 @@
       "title": "fugiat ea tempor"
     }
   ],
+  "people": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_person/36"
+        }
+      ]
+    }
+  ],
   "external_identifiers": [
     {
       "source": "archivesspace",

--- a/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
+++ b/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
@@ -171,15 +171,7 @@
     }
   ],
   "rights": [],
-  "agents": [
-    {
-      "external_identifiers": [
-        {
-          "source": "archivesspace",
-          "identifier": "/agents_organization/38"
-        }
-      ]
-    },
+  "people": [
     {
       "external_identifiers": [
         {
@@ -187,12 +179,14 @@
           "identifier": "/agents_person/19"
         }
       ]
-    },
+    }
+  ],
+  "organizations": [
     {
       "external_identifiers": [
         {
           "source": "archivesspace",
-          "identifier": "/agents_family/24"
+          "identifier": "/agents_organization/38"
         }
       ]
     },
@@ -209,6 +203,16 @@
         {
           "source": "archivesspace",
           "identifier": "/agents_organization/22"
+        }
+      ]
+    }
+  ],
+  "families": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_family/24"
         }
       ]
     }
@@ -233,5 +237,8 @@
       ]
     }
   ],
-  "type": "collection"
+  "type": "collection",
+  "formats": ["documents"],
+  "online": false,
+  "top_collection": "/repositories/2/resources/49"
 }

--- a/fixtures/valid/collection/5e16514c1af28a619dc5eaf4.json
+++ b/fixtures/valid/collection/5e16514c1af28a619dc5eaf4.json
@@ -105,7 +105,7 @@
     }
   ],
   "rights": [],
-  "agents": [
+  "people": [
     {
       "external_identifiers": [
         {
@@ -113,16 +113,19 @@
           "identifier": "/agents_organization/18"
         }
       ]
-    },
+    }
+  ],
+  "organizations": [
     {
       "external_identifiers": [
         {
           "source": "archivesspace",
-          "identifier": "/agents_person/7"
+          "identifier": "/agents_organization/18"
         }
       ]
     }
   ],
+  "families": [],
   "terms": [
     {
       "external_identifiers": [
@@ -159,5 +162,8 @@
       ]
     }
   ],
-  "type": "collection"
+  "type": "collection",
+  "formats": ["documents", "moving image"],
+  "online": true,
+  "top_collection": "/repositories/2/resources/49"
 }

--- a/fixtures/valid/collection/5e16514c2f0aeb2703835801.json
+++ b/fixtures/valid/collection/5e16514c2f0aeb2703835801.json
@@ -183,7 +183,7 @@
       "rights_type": "other"
     }
   ],
-  "agents": [
+  "people": [
     {
       "external_identifiers": [
         {
@@ -191,7 +191,10 @@
           "identifier": "/agents_person/13"
         }
       ]
-    },
+    }
+  ],
+  "organizations": [],
+  "families": [
     {
       "external_identifiers": [
         {
@@ -221,5 +224,8 @@
       ]
     }
   ],
-  "type": "collection"
+  "type": "collection",
+  "formats": ["audio"],
+  "online": false,
+  "top_collection": "/repositories/2/resources/49"
 }

--- a/fixtures/valid/collection/5e16514c5e5a38c49f32db05.json
+++ b/fixtures/valid/collection/5e16514c5e5a38c49f32db05.json
@@ -228,7 +228,7 @@
       "rights_type": "license"
     }
   ],
-  "agents": [
+  "people": [
     {
       "external_identifiers": [
         {
@@ -236,7 +236,10 @@
           "identifier": "/agents_person/6"
         }
       ]
-    },
+    }
+  ],
+  "organizations": [],
+  "families": [
     {
       "external_identifiers": [
         {
@@ -257,5 +260,8 @@
       ]
     }
   ],
-  "type": "collection"
+  "type": "collection",
+  "formats": ["photographs", "documents"],
+  "online": true,
+  "top_collection": "/repositories/2/resources/49"
 }

--- a/fixtures/valid/collection/5e16514c7a5575305c335aa5.json
+++ b/fixtures/valid/collection/5e16514c7a5575305c335aa5.json
@@ -162,7 +162,9 @@
     }
   ],
   "rights": [],
-  "agents": [],
+  "people": [],
+  "organizations": [],
+  "families": [],
   "terms": [
     {
       "external_identifiers": [
@@ -207,5 +209,8 @@
       ]
     }
   ],
-  "type": "collection"
+  "type": "collection",
+  "formats": ["documents"],
+  "online": false,
+  "top_collection": null
 }

--- a/fixtures/valid/object/5e164dbc01da72ffd828c3ca.json
+++ b/fixtures/valid/object/5e164dbc01da72ffd828c3ca.json
@@ -188,7 +188,8 @@
       "rights_type": "copyright"
     }
   ],
-  "agents": [
+  "people": [],
+  "organizations": [
     {
       "external_identifiers": [
         {
@@ -206,6 +207,7 @@
       ]
     }
   ],
+  "families": [],
   "terms": [
     {
       "external_identifiers": [
@@ -248,5 +250,8 @@
       ]
     }
   ],
-  "type": "object"
+  "type": "object",
+  "formats": ["moving image", "audio"],
+  "online": false,
+  "top_collection": "/repositories/2/resources/40"
 }

--- a/fixtures/valid/object/5e164dbc0f36cd59491a231f.json
+++ b/fixtures/valid/object/5e164dbc0f36cd59491a231f.json
@@ -162,7 +162,17 @@
       "rights_type": "other"
     }
   ],
-  "agents": [
+  "people": [
+    {
+      "external_identifiers": [
+        {
+          "source": "archivesspace",
+          "identifier": "/agents_person/36"
+        }
+      ]
+    }
+  ],
+  "organizations": [
     {
       "external_identifiers": [
         {
@@ -175,19 +185,15 @@
       "external_identifiers": [
         {
           "source": "archivesspace",
-          "identifier": "/agents_person/36"
-        }
-      ]
-    },
-    {
-      "external_identifiers": [
-        {
-          "source": "archivesspace",
           "identifier": "/agents_organization/20"
         }
       ]
     }
   ],
+  "families": [],
   "terms": [],
-  "type": "object"
+  "type": "object",
+  "formats": ["documents"],
+  "online": true,
+  "top_collection": "/repositories/2/resources/40"
 }

--- a/fixtures/valid/object/5e164dbc1aee795fbc75953c.json
+++ b/fixtures/valid/object/5e164dbc1aee795fbc75953c.json
@@ -269,7 +269,12 @@
       "rights_type": "statute"
     }
   ],
-  "agents": [],
+  "people": [],
+  "organizations": [],
+  "families": [],
   "terms": [],
-  "type": "object"
+  "type": "object",
+  "formats": ["audio"],
+  "online": false,
+  "top_collection": "/repositories/2/resources/40"
 }

--- a/fixtures/valid/object/5e164dbc2ea4bea04e0d8e86.json
+++ b/fixtures/valid/object/5e164dbc2ea4bea04e0d8e86.json
@@ -130,7 +130,9 @@
     }
   ],
   "rights": [],
-  "agents": [],
+  "people": [],
+  "organizations": [],
+  "families": [],
   "terms": [
     {
       "external_identifiers": [
@@ -141,5 +143,8 @@
       ]
     }
   ],
-  "type": "object"
+  "type": "object",
+  "formats": ["documents"],
+  "online": false,
+  "top_collection": "/repositories/2/resources/40"
 }

--- a/fixtures/valid/object/5e164dbc3ae235e3bff9ac0a.json
+++ b/fixtures/valid/object/5e164dbc3ae235e3bff9ac0a.json
@@ -156,7 +156,12 @@
       "rights_type": "copyright"
     }
   ],
-  "agents": [],
+  "people": [],
+  "organizations": [],
+  "families": [],
   "terms": [],
-  "type": "object"
+  "type": "object",
+  "formats": ["photographs"],
+  "online": true,
+  "top_collection": "/repositories/2/resources/40"
 }

--- a/rac_schemas/__init__.py
+++ b/rac_schemas/__init__.py
@@ -39,8 +39,9 @@ def is_valid(data, schema_name):
         with open(Path(schemas_dir) / filename, "r") as sf:
             object_schema = json.load(sf)
             resolver = jsonschema.RefResolver.from_schema(base_schema)
+            format_checker = jsonschema.FormatChecker()
             validator = jsonschema.Draft7Validator(
-                object_schema, resolver=resolver)
+                object_schema, resolver=resolver, format_checker=format_checker)
             try:
                 validator.validate(data)
             except jsonschema.exceptions.ValidationError as e:

--- a/rac_schemas/schemas/agent.json
+++ b/rac_schemas/schemas/agent.json
@@ -70,6 +70,30 @@
 					}]
 				}
 			},
+			"people": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"organizations": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"families": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
 			"external_identifiers": {
 				"type": "array",
 				"minItems": 1,

--- a/rac_schemas/schemas/base.json
+++ b/rac_schemas/schemas/base.json
@@ -21,6 +21,7 @@
 					"title": "Begin Date",
 					"description": "Begin date of the objects described",
 					"minLength": 1,
+					"format": "date",
 					"examples": [
 						"1939-06-03"
 					]
@@ -31,6 +32,7 @@
 					"title": "End Date",
 					"description": "End date of the objects described",
 					"minLength": 1,
+					"format": "date",
 					"examples": [
 						"1991-05-23"
 					]
@@ -523,6 +525,7 @@
 					"type": ["string", "null"],
 					"title": "Rights Statement Determination Date",
 					"minLength": 1,
+					"format": "date",
 					"examples": [
 						"2019-08-23"
 					],
@@ -552,20 +555,20 @@
 					"type": "string",
 					"title": "Rights Begin Date",
 					"minLength": 1,
+					"format": "date",
 					"examples": [
 						"2019-08-23"
-					],
-					"pattern": "^(.*)$"
+					]
 				},
 				"end": {
 					"$id": "#/definitions/rights_statement/properties/end",
 					"type": "string",
 					"title": "Rights End Date",
 					"minLength": 1,
+					"format": "date",
 					"examples": [
 						"2019-08-23"
-					],
-					"pattern": "^(.*)$"
+					]
 				},
 				"copyright_status": {
 					"$id": "#/definitions/rights_statement/properties/copyright_status",
@@ -714,16 +717,19 @@
 						"type": "string"
 					},
 					"determination_date": {
-						"type": ["string", "null"]
+						"type": ["string", "null"],
+						"format": "date"
 					},
 					"jurisdiction": {
 						"type": ["string", "null"]
 					},
 					"start_date": {
-						"type": "string"
+						"type": "string",
+						"format": "date"
 					},
 					"end_date": {
-						"type": "string"
+						"type": "string",
+						"format": "date"
 					},
 					"note": {
 						"type": "string"
@@ -759,7 +765,8 @@
 									"format": "date"
 								},
 								"end_date": {
-									"type": "string"
+									"type": "string",
+									"format": "date"
 								},
 								"note": {
 									"type": "string"

--- a/rac_schemas/schemas/collection.json
+++ b/rac_schemas/schemas/collection.json
@@ -12,8 +12,11 @@
 			"dates",
 			"extents",
 			"external_identifiers",
+			"formats",
 			"languages",
+			"online",
 			"title",
+			"top_collection",
 			"type"
 		],
 		"properties": {
@@ -68,7 +71,23 @@
 					}]
 				}
 			},
-			"agents": {
+			"people": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"organizations": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"families": {
 				"type": "array",
 				"items": {
 					"allOf": [{
@@ -117,6 +136,28 @@
 						"$ref": "base.json#/definitions/reference"
 					}]
 				}
+			},
+			"formats": {
+				"type": "array",
+				"items": {
+						"oneOf": [
+							{
+								"type": "string",
+								"enum": [
+									"documents",
+									"audio",
+									"photographs",
+									"moving image"
+								]
+							}
+						]
+					}
+			},
+			"online": {
+				"type": "boolean"
+			},
+			"top_collection": {
+				"type": ["string", "null"]
 			},
 			"external_identifiers": {
 				"type": "array",

--- a/rac_schemas/schemas/object.json
+++ b/rac_schemas/schemas/object.json
@@ -11,7 +11,10 @@
 			"dates",
 			"extents",
 			"external_identifiers",
+			"formats",
+			"online",
 			"title",
+			"top_collection",
 			"type"
 		],
 		"properties": {
@@ -33,7 +36,7 @@
 				]
 			},
 			"dates": {
-				"type": ["array", "null"],
+				"type": ["array"],
 				"minItems": 1,
 				"items": {
 					"allOf": [{
@@ -42,7 +45,8 @@
 				}
 			},
 			"extents": {
-				"type": ["array", "null"],
+				"type": ["array"],
+				"minItems": 1,
 				"items": {
 					"allOf": [{
 						"$ref": "base.json#/definitions/extent"
@@ -65,7 +69,23 @@
 					}]
 				}
 			},
-			"agents": {
+			"people": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"organizations": {
+				"type": "array",
+				"items": {
+					"allOf": [{
+						"$ref": "base.json#/definitions/reference"
+					}]
+				}
+			},
+			"families": {
 				"type": "array",
 				"items": {
 					"allOf": [{
@@ -96,6 +116,28 @@
 						"$ref": "base.json#/definitions/reference"
 					}]
 				}
+			},
+			"formats": {
+				"type": "array",
+				"items": {
+						"oneOf": [
+							{
+								"type": "string",
+								"enum": [
+									"documents",
+									"audio",
+									"photographs",
+									"moving image"
+								]
+							}
+						]
+					}
+			},
+			"online": {
+				"type": "boolean"
+			},
+			"top_collection": {
+				"type": ["string", "null"]
 			},
 			"external_identifiers": {
 				"type": "array",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema==3.2.0
+jsonschema[format]==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='rac_schemas',
-      version='0.12.1',
+      version='0.13',
       description='RAC JSON Schemas and validators',
       url='http://github.com/RockefellerArchiveCenter/rac_schemas',
       author='Rockefeller Archive Center',


### PR DESCRIPTION
Adds additional fields needed for search, fixes #17 
Uses format checking for dates, fixes #16 

@p-galligan requesting your review to get another pair of eyes on this. I've added some fields to `collection` and `object` validation, and broken some existing fields into multiples. These changes are driven by desired/required functionality in the DIMES-TNG search interface:
- Added a `top_collection` field, which will help us group results by collection.
- Added a `formats` field so we can facet on that.
- Added an `online` boolean so we can filter by things that are online or not
- Broke the `agents` key into `people`, `organizations` and `families` (and added these to `agent` objects as well) so we can facet on particular kinds of agents rather than all of them.

Dose anything about this look off to you? Any suggestions for simplification or clarification?