### PR TITLE
Using regex validation for dates

### DIFF
--- a/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
+++ b/fixtures/valid/collection/5e16514c00b13f54a1a0592b.json
@@ -1,8 +1,8 @@
 {
   "dates": [
     {
-      "begin": "1926-06-04",
-      "end": "2012-09-17",
+      "begin": "1926-06",
+      "end": "2012",
       "type": "single",
       "label": "modified",
       "source": "archivesspace",

--- a/rac_schemas/__init__.py
+++ b/rac_schemas/__init__.py
@@ -1,5 +1,6 @@
 import json
 import jsonschema
+import re
 from pathlib import Path
 
 from .exceptions import ValidationError
@@ -15,6 +16,26 @@ def handle_schema_filename(filename):
         else:
             filename = filename + ".json"
     return filename
+
+
+def is_date(value, instance):
+    if instance.count("-") == 2:
+        pattern = re.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
+    elif instance.count("-") == 1:
+        pattern = re.compile("^[0-9]{4}-[0-9]{2}$")
+    else:
+        pattern = re.compile("^[0-9]{4}$")
+    return pattern.match(instance)
+
+
+type_checker = jsonschema.Draft7Validator.TYPE_CHECKER.redefine(
+    "date", is_date)
+validators = jsonschema.Draft7Validator.VALIDATORS
+validators["date"] = is_date
+CustomValidator = jsonschema.validators.extend(
+    jsonschema.Draft7Validator,
+    type_checker=type_checker,
+    validators=validators)
 
 
 def is_valid(data, schema_name):
@@ -39,9 +60,7 @@ def is_valid(data, schema_name):
         with open(Path(schemas_dir) / filename, "r") as sf:
             object_schema = json.load(sf)
             resolver = jsonschema.RefResolver.from_schema(base_schema)
-            format_checker = jsonschema.FormatChecker()
-            validator = jsonschema.Draft7Validator(
-                object_schema, resolver=resolver, format_checker=format_checker)
+            validator = CustomValidator(object_schema, resolver=resolver)
             try:
                 validator.validate(data)
             except jsonschema.exceptions.ValidationError as e:

--- a/rac_schemas/__init__.py
+++ b/rac_schemas/__init__.py
@@ -28,16 +28,6 @@ def is_date(value, instance):
     return pattern.match(instance)
 
 
-type_checker = jsonschema.Draft7Validator.TYPE_CHECKER.redefine(
-    "date", is_date)
-validators = jsonschema.Draft7Validator.VALIDATORS
-validators["date"] = is_date
-CustomValidator = jsonschema.validators.extend(
-    jsonschema.Draft7Validator,
-    type_checker=type_checker,
-    validators=validators)
-
-
 def is_valid(data, schema_name):
     """Main method to validate data against a JSON schema.
 
@@ -60,6 +50,14 @@ def is_valid(data, schema_name):
         with open(Path(schemas_dir) / filename, "r") as sf:
             object_schema = json.load(sf)
             resolver = jsonschema.RefResolver.from_schema(base_schema)
+            type_checker = jsonschema.Draft7Validator.TYPE_CHECKER.redefine(
+                "date", is_date)
+            validators = jsonschema.Draft7Validator.VALIDATORS
+            validators["date"] = is_date
+            CustomValidator = jsonschema.validators.extend(
+                jsonschema.Draft7Validator,
+                type_checker=type_checker,
+                validators=validators)
             validator = CustomValidator(object_schema, resolver=resolver)
             try:
                 validator.validate(data)

--- a/rac_schemas/schemas/base.json
+++ b/rac_schemas/schemas/base.json
@@ -21,18 +21,17 @@
 					"title": "Begin Date",
 					"description": "Begin date of the objects described",
 					"minLength": 1,
-					"format": "date",
+					"type": "date",
 					"examples": [
 						"1939-06-03"
 					]
 				},
 				"end": {
 					"$id": "#/definitions/date/properties/end",
-					"type": ["string", "null"],
+					"type": ["date", "null"],
 					"title": "End Date",
 					"description": "End date of the objects described",
 					"minLength": 1,
-					"format": "date",
 					"examples": [
 						"1991-05-23"
 					]
@@ -522,10 +521,8 @@
 				},
 				"determination_date": {
 					"$id": "#/definitions/rights_statement/properties/determination_date",
-					"type": ["string", "null"],
+					"type": "date",
 					"title": "Rights Statement Determination Date",
-					"minLength": 1,
-					"format": "date",
 					"examples": [
 						"2019-08-23"
 					],
@@ -552,20 +549,16 @@
 				},
 				"begin": {
 					"$id": "#/definitions/rights_statement/properties/begin",
-					"type": "string",
+					"type": "date",
 					"title": "Rights Begin Date",
-					"minLength": 1,
-					"format": "date",
 					"examples": [
 						"2019-08-23"
 					]
 				},
 				"end": {
 					"$id": "#/definitions/rights_statement/properties/end",
-					"type": "string",
+					"type": "date",
 					"title": "Rights End Date",
-					"minLength": 1,
-					"format": "date",
 					"examples": [
 						"2019-08-23"
 					]
@@ -717,19 +710,16 @@
 						"type": "string"
 					},
 					"determination_date": {
-						"type": ["string", "null"],
-						"format": "date"
+						"type": ["date", "null"]
 					},
 					"jurisdiction": {
 						"type": ["string", "null"]
 					},
 					"start_date": {
-						"type": "string",
-						"format": "date"
+						"type": "date"
 					},
 					"end_date": {
-						"type": "string",
-						"format": "date"
+						"type": "date"
 					},
 					"note": {
 						"type": "string"
@@ -761,12 +751,10 @@
 										"delete"]
 								},
 								"start_date": {
-									"type": ["string", "null"],
-									"format": "date"
+									"type": ["date", "null"]
 								},
 								"end_date": {
-									"type": "string",
-									"format": "date"
+									"type": "date"
 								},
 								"note": {
 									"type": "string"

--- a/rac_schemas/schemas/base.json
+++ b/rac_schemas/schemas/base.json
@@ -521,7 +521,7 @@
 				},
 				"determination_date": {
 					"$id": "#/definitions/rights_statement/properties/determination_date",
-					"type": "date",
+					"type": ["date", "null"],
 					"title": "Rights Statement Determination Date",
 					"examples": [
 						"2019-08-23"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema[format]==3.2.0
+jsonschema==3.2.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='rac_schemas',
-      version='0.13',
+      version='0.14',
       description='RAC JSON Schemas and validators',
       url='http://github.com/RockefellerArchiveCenter/rac_schemas',
       author='Rockefeller Archive Center',

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,7 +3,6 @@ import unittest
 from os import listdir
 from os.path import abspath, dirname, join
 
-from jsonschema.validators import validator_for
 from rac_schemas import handle_schema_filename, is_valid
 from rac_schemas.exceptions import ValidationError
 
@@ -16,17 +15,14 @@ fixtures_dir = join(base_path, "fixtures")
 class TestSchemas(unittest.TestCase):
 
     def test_schemas_valid(self):
-        """Ensures all schemas are valid.
+        """Ensures all schemas are valid JSON.
 
         Attempts to load each of the schemas using the json library. If any of
         them are invalid JSON a json.JSONDecodeError exception will be thrown.
-        Also uses jsonschema's `check_schema` method to check schemas.
         """
         for f in listdir(schemas_dir):
             with open(join(schemas_dir, f)) as sf:
-                schema = json.load(sf)
-                cls = validator_for(schema)
-                cls.check_schema(schema)
+                json.load(sf)
 
     def test_schema_filename(self):
         """Ensures that schema filenames are parsed properly."""
@@ -51,7 +47,6 @@ class TestSchemas(unittest.TestCase):
         for object_type in listdir(join(fixtures_dir, "valid")):
             for f in listdir(join(fixtures_dir, "valid", object_type)):
                 with open(join(fixtures_dir, "valid", object_type, f), "r") as df:
-                    print(object_type, f)
                     data = json.load(df)
                     is_valid(data, object_type)
         for object_type in listdir(join(fixtures_dir, "invalid")):


### PR DESCRIPTION
`python-jsonschema` uses `strptime` to parse date formats, which means that dates such as `2019` or `2019-01` will be declared invalid. This adds a custom type of `date` which uses regex checking instead.