### PR TITLE
Ensure instances are strings

### DIFF
--- a/rac_schemas/__init__.py
+++ b/rac_schemas/__init__.py
@@ -19,6 +19,8 @@ def handle_schema_filename(filename):
 
 
 def is_date(value, instance):
+    if not isinstance(instance, str):
+        return False
     if instance.count("-") == 2:
         pattern = re.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}$")
     elif instance.count("-") == 1:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='rac_schemas',
-      version='0.14',
+      version='0.14.1',
       description='RAC JSON Schemas and validators',
       url='http://github.com/RockefellerArchiveCenter/rac_schemas',
       author='Rockefeller Archive Center',


### PR DESCRIPTION
Returns `False` if instances are not strings.