### PR TITLE
Add authorized name

### DIFF
--- a/fixtures/invalid/agent/invalid-agent-type.json
+++ b/fixtures/invalid/agent/invalid-agent-type.json
@@ -49,6 +49,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/invalid-authorized-name.json
+++ b/fixtures/invalid/agent/invalid-authorized-name.json
@@ -48,7 +48,8 @@
         }
     ],
     "people": [],
-    "authorized_name": "Rockefeller Foundation. Paris (France)",
+    "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": 123,
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/invalid-date.json
+++ b/fixtures/invalid/agent/invalid-date.json
@@ -58,6 +58,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-agent-type.json
+++ b/fixtures/invalid/agent/no-agent-type.json
@@ -48,6 +48,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-authorized-name.json
+++ b/fixtures/invalid/agent/no-authorized-name.json
@@ -48,7 +48,7 @@
         }
     ],
     "people": [],
-    "authorized_name": "Rockefeller Foundation. Paris (France)",
+    "title": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-category.json
+++ b/fixtures/invalid/agent/no-category.json
@@ -48,6 +48,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-external-ids.json
+++ b/fixtures/invalid/agent/no-external-ids.json
@@ -44,6 +44,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-group.json
+++ b/fixtures/invalid/agent/no-group.json
@@ -28,6 +28,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/invalid/agent/no-type.json
+++ b/fixtures/invalid/agent/no-type.json
@@ -49,5 +49,6 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/valid/agent/2hb5qexuwrxghfdj58bzh9ize4.json
+++ b/fixtures/valid/agent/2hb5qexuwrxghfdj58bzh9ize4.json
@@ -35,6 +35,7 @@
     ],
     "people": [],
     "title": "Rockefeller Foundation. Paris (France)",
+    "authorized_name": "Rockefeller Foundation. Paris (France)",
     "type": "agent",
     "uri": "/agents/2hb5qexuwrxghfdj58bzh9ize4"
 }

--- a/fixtures/valid/agent/2kp6ctoi4s6guncxnnv4tnujn3.json
+++ b/fixtures/valid/agent/2kp6ctoi4s6guncxnnv4tnujn3.json
@@ -35,6 +35,7 @@
         }
     ],
     "title": "Morrow, Hugh",
+    "authorized_name": "Morrow, Hugh",
     "type": "agent",
     "uri": "/agents/2kp6ctoi4s6guncxnnv4tnujn3"
 }

--- a/fixtures/valid/agent/3ba7nur6r4x38r226x3khsz9n5.json
+++ b/fixtures/valid/agent/3ba7nur6r4x38r226x3khsz9n5.json
@@ -53,6 +53,7 @@
         }
     ],
     "title": "Rockefeller, David",
+    "authorized_name": "Rockefeller, David",
     "type": "agent",
     "uri": "/agents/3ba7nur6r4x38r226x3khsz9n5"
 }

--- a/fixtures/valid/agent/3gj3qien7hjv7z6shbdzjcinr2.json
+++ b/fixtures/valid/agent/3gj3qien7hjv7z6shbdzjcinr2.json
@@ -33,6 +33,7 @@
     ],
     "people": [],
     "title": "Columbia University",
+    "authorized_name": "Columbia University",
     "type": "agent",
     "uri": "/agents/3gj3qien7hjv7z6shbdzjcinr2"
 }

--- a/fixtures/valid/agent/3snxgfvn7ha9mbnbxg9u53df44.json
+++ b/fixtures/valid/agent/3snxgfvn7ha9mbnbxg9u53df44.json
@@ -35,6 +35,7 @@
     ],
     "people": [],
     "title": "United Nations",
+    "authorized_name": "United Nations",
     "type": "agent",
     "uri": "/agents/3snxgfvn7ha9mbnbxg9u53df44"
 }

--- a/rac_schemas/schemas/agent.json
+++ b/rac_schemas/schemas/agent.json
@@ -8,11 +8,11 @@
 		"type": "object",
 		"title": "Agents",
 		"required": [
+			"authorized_name",
 			"category",
 			"external_identifiers",
 			"group",
 			"title",
-			"authorized_name",
 			"type",
 			"agent_type"
 		],

--- a/rac_schemas/schemas/agent.json
+++ b/rac_schemas/schemas/agent.json
@@ -12,6 +12,7 @@
 			"external_identifiers",
 			"group",
 			"title",
+			"authorized_name",
 			"type",
 			"agent_type"
 		],
@@ -48,6 +49,17 @@
 				"description": "Title for Agent",
 				"examples": [
 					"Lawson Foundation"
+				],
+				"pattern": "^(.*)$"
+			},
+			"authorized_name": {
+				"$id": "#/agent/properties/authorized_name",
+				"type": "string",
+				"title": "Agent Authorized Name",
+				"description": "Authorized Name for Agent",
+				"examples": [
+					"Lawson Foundation",
+					"Rockefeller, Nelson"
 				],
 				"pattern": "^(.*)$"
 			},


### PR DESCRIPTION
Adds authorized name property to the agent schema.

I have not attempted any regex to enforce indirect order because that would not be upheld for the corporate agent types. We could do some if/then statements that would add complexity here that probably isn't necessary.